### PR TITLE
Fixing up rpm_limiter

### DIFF
--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -94,7 +94,7 @@ typedef struct mixerConfig_s {
     uint16_t govenor_i;
     uint16_t govenor_d;
     uint16_t govenor_ff;
-    uint8_t govenor_rpm_limit;
+    uint16_t govenor_rpm_limit;
     uint16_t govenor_aggressiveness;
     uint8_t govenor_cell_count;
     uint16_t govenor_debug_throttle;

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -330,8 +330,8 @@ void mixerInitProfile(void)
 // mixerRuntime.govenorExpectedThrottleLimit = mixerRuntime.govenorExpectedThrottleLimit > 1.0f ? 1.0f : mixerRuntime.govenorExpectedThrottleLimit;
 mixerRuntime.govenorExpectedThrottleLimit = 1.0f;
 mixerRuntime.govenorPGain = mixerConfig()->govenor_p * 0.0000015f;
-mixerRuntime.govenorIGain = mixerConfig()->govenor_i * 0.00001f * pidGetDT();
-mixerRuntime.govenorDGain = mixerConfig()->govenor_d * 0.0000003f * pidGetPidFrequency();
+mixerRuntime.govenorIGain = mixerConfig()->govenor_i * 0.0001f * pidGetDT();
+mixerRuntime.govenorDGain = mixerConfig()->govenor_d * 0.00000003f * pidGetPidFrequency();
 mixerRuntime.govenorI = 0;
 mixerRuntime.govenorPrevThrottle = 0;
 // mixerRuntime.govenorFFGain = 0.05f * (float)(mixerConfig()->govenor_ff) * 0.001f;


### PR DESCRIPTION
Alright here's where I'm finishing off for the night (day?)
- tweaked pid multipliers (please start with the pids below)
- changed govenor_rpm_limit to be 16 bit (so we can use more than 255 values)
- fixed motor saturation detection (only tested with throttle linearization)
- fixed i-term windup when motor saturation is detected

set rpm_limiter = ON
set rpm_limiter_p = 100
set rpm_limiter_i = 50
set rpm_limiter_d = 25
set rpm_limiter_rpm_limit = 130
set rpm_limiter_idle_rpm = 14
set rpm_limiter_full_linearization = ON